### PR TITLE
Cobblemon challenge 1.19.2 fabric

### DIFF
--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/battle/ChallengeBattleBuilder.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/battle/ChallengeBattleBuilder.java
@@ -23,14 +23,14 @@ public class ChallengeBattleBuilder {
     public static Vector<PokemonEntity> clonedPokemonList = new Vector<>();
     public static Vector<PokemonBattle> challengeBattles = new Vector<>();
     private ChallengeFormat format = ChallengeFormat.STANDARD_6V6;
-    public void lvlxpvp(ServerPlayer player1, ServerPlayer player2, BattleFormat battleFormat, int level, List<Integer> player1Selection, List<Integer> player2Selection) throws ChallengeBuilderException {
+    public void lvlxpvp(ServerPlayer player1, ServerPlayer player2, BattleFormat battleFormat, int minLevel, int maxLevel, int handicapP1, int handicapP2, List<Integer> player1Selection, List<Integer> player2Selection) throws ChallengeBuilderException {
 
         PartyStore p1Party = Cobblemon.INSTANCE.getStorage().getParty(player1);
         PartyStore p2Party = Cobblemon.INSTANCE.getStorage().getParty(player2);
 
         // Clone parties so original is not effected
-        List<BattlePokemon> player1Team = createBattleTeamFromParty(p1Party, player1Selection, level);
-        List<BattlePokemon> player2Team = createBattleTeamFromParty(p2Party, player2Selection, level);
+        List<BattlePokemon> player1Team = createBattleTeamFromParty(p1Party, player1Selection, minLevel, maxLevel, handicapP1);
+        List<BattlePokemon> player2Team = createBattleTeamFromParty(p2Party, player2Selection, minLevel, maxLevel, handicapP2);
 
         PlayerBattleActor player1Actor = new PlayerBattleActor(player1.getUUID(), player1Team);
         PlayerBattleActor player2Actor = new PlayerBattleActor(player2.getUUID(), player2Team);
@@ -41,7 +41,8 @@ public class ChallengeBattleBuilder {
     }
 
     // Method to create our own clones according to the format
-    private List<BattlePokemon> createBattleTeamFromParty(PartyStore party, List<Integer> selectedSlots, int level) throws ChallengeBuilderException {
+    private List<BattlePokemon> createBattleTeamFromParty(PartyStore party, List<Integer> selectedSlots, int minLevel, int maxLevel, int handicap) throws ChallengeBuilderException {
+
         List<BattlePokemon> battlePokemonList = new ArrayList<BattlePokemon>();
         if (format == ChallengeFormat.STANDARD_6V6) {
             int leadSlot = selectedSlots.get(0);
@@ -50,13 +51,16 @@ public class ChallengeBattleBuilder {
                 CobblemonChallenge.LOGGER.error("Mysterious null lead pokemon selected.");
                 throw new ChallengeBuilderException();
             }
+
             BattlePokemon leadBattlePokemon = BattlePokemon.Companion.safeCopyOf(leadPokemon);
-            battlePokemonList.add(ChallengeUtil.applyFormatTransformations(format,leadBattlePokemon, level));
+            int adjustedLevel = ChallengeUtil.getBattlePokemonAdjustedLevel(leadPokemon.getLevel(), minLevel, maxLevel, handicap);
+            battlePokemonList.add(ChallengeUtil.applyFormatTransformations(format,leadBattlePokemon, adjustedLevel));
             for (int slot = 0; slot < party.size(); slot++) {
                 if (slot != leadSlot) {
                     Pokemon pokemon = party.get(slot);
                     if (pokemon != null) {
-                        BattlePokemon battlePokemon = ChallengeUtil.applyFormatTransformations(format, BattlePokemon.Companion.safeCopyOf(pokemon), level);
+                        adjustedLevel = ChallengeUtil.getBattlePokemonAdjustedLevel(pokemon.getLevel(), minLevel, maxLevel, handicap);
+                        BattlePokemon battlePokemon = ChallengeUtil.applyFormatTransformations(format, BattlePokemon.Companion.safeCopyOf(pokemon), adjustedLevel);
                         battlePokemonList.add(battlePokemon);
                     }
                 }

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/config/ChallengeConfig.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/config/ChallengeConfig.java
@@ -9,6 +9,7 @@ public class ChallengeConfig {
     public static Boolean CHALLENGE_DISTANCE_RESTRICTION;
     public static int MAX_CHALLENGE_DISTANCE;
     public static int DEFAULT_CHALLENGE_LEVEL;
+    public static int DEFAULT_HANDICAP;
     public static int REQUEST_EXPIRATION_MILLIS;
     public static int CHALLENGE_COOLDOWN_MILLIS;
 
@@ -23,6 +24,7 @@ public class ChallengeConfig {
         configs.addKeyValuePair(new Pair<>("challengeDistanceRestriction", true));
         configs.addKeyValuePair(new Pair<>("maxChallengeDistance", 50));
         configs.addKeyValuePair(new Pair<>("defaultChallengeLevel", 50));
+        configs.addKeyValuePair(new Pair<>("defaultHandicap", 0));
         configs.addKeyValuePair(new Pair<>("challengeExpirationTime", 60000));
         configs.addKeyValuePair(new Pair<>("challengeCooldownTime", 5000));
     }
@@ -31,6 +33,7 @@ public class ChallengeConfig {
         CHALLENGE_COOLDOWN_MILLIS = CONFIG.getOrDefault("challengeCooldownTime", 5000);
         CHALLENGE_DISTANCE_RESTRICTION = CONFIG.getOrDefault("challengeDistanceRestriction", true);
         DEFAULT_CHALLENGE_LEVEL = CONFIG.getOrDefault("defaultChallengeLevel", 50);
+        DEFAULT_HANDICAP = CONFIG.getOrDefault("defaultHandicap", 0);
         MAX_CHALLENGE_DISTANCE = CONFIG.getOrDefault("maxChallengeDistance", 50);
         REQUEST_EXPIRATION_MILLIS = CONFIG.getOrDefault("challengeExpirationTime", 60000);
     }

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonMenuProvider.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonMenuProvider.java
@@ -70,15 +70,19 @@ public class LeadPokemonMenuProvider implements MenuProvider {
         PartyStore p2Party = Cobblemon.INSTANCE.getStorage().getParty(rival);
 
         setupGlassFiller(leadPokemonMenu);
+        int handicapP1 = (this.selector == request.challengerPlayer()) ? request.handicapP1() : request.handicapP2();
+        int handicapP2 = (this.selector == request.challengerPlayer()) ? request.handicapP2() : request.handicapP1();
+
         for (int x = 0; x < p1Party.size(); x ++) {
             int itemSlot = x * 9; // Lefthand column of the menu
             Pokemon pokemon = p1Party.get(x);
             if (pokemon == null) // Skip any empty slots in the pokemon team
                 continue;
             BattlePokemon copy = BattlePokemon.Companion.safeCopyOf(pokemon);
-            pokemon = ChallengeUtil.applyFormatTransformations(ChallengeFormat.STANDARD_6V6, copy, request.level()).getEffectedPokemon(); // Apply battle transformations to each pokemon
+            int adjustedLevelP1 = ChallengeUtil.getBattlePokemonAdjustedLevel(pokemon.getLevel(), request.minLevel(), request.maxLevel(), handicapP1);
+            pokemon = ChallengeUtil.applyFormatTransformations(ChallengeFormat.STANDARD_6V6, copy, adjustedLevelP1).getEffectedPokemon(); // Apply battle transformations to each pokemon
             ItemStack pokemonItem = PokemonItem.from(pokemon, 1);
-            pokemonItem.setHoverName(Component.literal(ChatFormatting.AQUA + String.format("%s (lvl%d)", pokemon.getDisplayName().getString(), request.level())));
+            pokemonItem.setHoverName(Component.literal(ChatFormatting.AQUA + String.format("%s (lvl%d)", pokemon.getDisplayName().getString(), adjustedLevelP1)));
             ListTag pokemonLoreTag = ChallengeUtil.generateLoreTagForPokemon(pokemon);
             pokemonItem.getOrCreateTagElement("display").put("Lore", pokemonLoreTag);
             leadPokemonMenu.setItem(itemSlot, leadPokemonMenu.getStateId(), pokemonItem);
@@ -93,7 +97,8 @@ public class LeadPokemonMenuProvider implements MenuProvider {
             }
             if (selectionSession.teamPreviewOn()) {
                 ItemStack pokemonItem = PokemonItem.from(pokemon, 1);
-                pokemonItem.setHoverName(Component.literal(ChatFormatting.RED + String.format("%s's %s (lvl%d)", rival.getDisplayName().getString(), pokemon.getDisplayName().getString(), request.level())));
+                int adjustedLevelP2 = ChallengeUtil.getBattlePokemonAdjustedLevel(pokemon.getLevel(), request.minLevel(), request.maxLevel(), handicapP2);
+                pokemonItem.setHoverName(Component.literal(ChatFormatting.RED + String.format("%s's %s (lvl%d)", rival.getDisplayName().getString(), pokemon.getDisplayName().getString(), adjustedLevelP2)));
                 leadPokemonMenu.setItem(itemSlot, leadPokemonMenu.getStateId(), pokemonItem);
             } else {
                 ItemStack pokemonItem = new ItemStack(CobblemonItems.POKE_BALL.get());

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonSelectionSession.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonSelectionSession.java
@@ -61,13 +61,16 @@ public class LeadPokemonSelectionSession {
     }
 
     private void beginBattle() {
-        int level = originRequest.level();
+        int minLevel = originRequest.minLevel();
+        int maxLevel = originRequest.maxLevel();
+        int handicapP1 = originRequest.handicapP1();
+        int handicapP2 = originRequest.handicapP2();
         SESSIONS_TO_CANCEL.add(this);
         challengerMenuProvider.forceCloseMenu();
         challengedMenuProvider.forceCloseMenu();
         ChallengeBattleBuilder challengeBuilder = new ChallengeBattleBuilder();
         try {
-            challengeBuilder.lvlxpvp(originRequest.challengerPlayer(), originRequest.challengedPlayer(), BattleFormat.Companion.getGEN_9_SINGLES(), level, challengerMenuProvider.selectedSlots, challengedMenuProvider.selectedSlots);
+            challengeBuilder.lvlxpvp(originRequest.challengerPlayer(), originRequest.challengedPlayer(), BattleFormat.Companion.getGEN_9_SINGLES(), minLevel, maxLevel, handicapP1, handicapP2, challengerMenuProvider.selectedSlots, challengedMenuProvider.selectedSlots);
         } catch (ChallengeBuilderException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/util/ChallengeUtil.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/util/ChallengeUtil.java
@@ -56,9 +56,9 @@ public class ChallengeUtil {
         return player.getServer().getPlayerList().getPlayer(player.getUUID()) != null;
     }
 
-    public static ChallengeCommand.ChallengeRequest createChallengeRequest(ServerPlayer challengerPlayer, ServerPlayer challengedPlayer, int level, boolean preview) {
+    public static ChallengeCommand.ChallengeRequest createChallengeRequest(ServerPlayer challengerPlayer, ServerPlayer challengedPlayer, int minLevel, int maxLevel, int handicapP1, int handicapP2, boolean preview) {
         String key = UUID.randomUUID().toString().replaceAll("-", "");
-        ChallengeCommand.ChallengeRequest newRequest = new ChallengeCommand.ChallengeRequest(key, challengerPlayer, challengedPlayer, level, preview, System.currentTimeMillis());
+        ChallengeCommand.ChallengeRequest newRequest = new ChallengeCommand.ChallengeRequest(key, challengerPlayer, challengedPlayer, minLevel, maxLevel, handicapP1, handicapP2, preview, System.currentTimeMillis());
         return newRequest;
     }
 
@@ -123,5 +123,14 @@ public class ChallengeUtil {
             pokemon.getEffectedPokemon().heal();
         }
         return pokemon;
+    }
+
+    // Method for clamping Battle Pokemon to level range, between 1-100, & applying handicap
+    //      > the handicap applied AFTER level clamp to range
+    //      > A players level may be outside this range after the handicap is applied
+    //      >  But, the finalized handicap will be a hard clamped to (1,100)
+    public static int getBattlePokemonAdjustedLevel(int actualLevel, int minLevel, int maxLevel, int handicap) {
+        int adjustedLevel = (actualLevel < minLevel) ? minLevel + handicap : Math.min(actualLevel, maxLevel) + handicap;
+        return (adjustedLevel < 1) ? 1 : Math.min(adjustedLevel, 100);
     }
 }


### PR DESCRIPTION
Hey! Here is the changes I made to implement min/maxLevel & handicap functionality. I have tested everything on the Fabric 1.5 1.20.1 version. There were no errors there & everything functioned as expected. Some colors & property names may not be what you would prefer, so feel free to change them as you see fit. I did my best to name everything off of it's functionality. Feel free to reach out if you have any questions!


Here are the differences between Fabric & Forge in the updates I made:

    1. ChallengeConfig files
        a. Formating of properties is different
    2. ChallengeCommand files
        a. Only how the properties are formatted -> ".get()" used in Forge


Here are the individual changes made to each of the six files:

    ChallengeConfig:
        - Added DEFAULT_HANDICAP/"defaultHandicap" to config

    ChallengeCommand:
        - Refactored ChallengeRequest record with min/max level & handicap
        - Refactored ChallengeCommand.register to have 12 versions (TODO: Refactor to be more flexible & concise)
        - Refactored ChallengeCommand.challengePlayer to include min/max level & handicap
        - Added check in ChallengeCommand.challengePlayer to clamp minLevel to maxLevel
        - Refactored notification format in ChallengeCommand.challengePlayer to display level range & handicap to challengedPlayer

    ChallengeUtil:
        - Refactored ChallengeUtil.createChallengeRequest to intake min/maxLevel & handicap
        - Added method ChallengeUtil.getBattlePokemonAdjustedLevel to handle each individual pokemon level according to min/maxLevel, handicap, & clamp to (1,100)

    LeadPokemonSelectionSession:
        - Refactored LeadPokemonSelectionSession.beginBattle to use min/maxLevel & handicap to pokemon

    LeadPokemonMenuProvider:
        - Refactored LeadPokemonMenuProvider.setupPokemonRepresentation to apply min/maxLevel & handicap to pokemon

    ChallengeBattleBuilder:
        - Refactored ChallengeBattleBuilder.lvlxpvp to intake & pass min/maxLevel & handicap to ChallengeBattleBuilder.createBattleTeamFromParty
        - Refactored ChallengeBattleBuilder.createBattleTeamFromParty to apply min/maxLevel & handicap to pokemon