### PR TITLE
Cobblemon challenge 1.20.1 bug fix

### DIFF
--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/battle/ChallengeBattleBuilder.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/battle/ChallengeBattleBuilder.java
@@ -24,14 +24,15 @@ public class ChallengeBattleBuilder {
     public static Vector<PokemonEntity> clonedPokemonList = new Vector<>();
     public static Vector<PokemonBattle> challengeBattles = new Vector<>();
     private ChallengeFormat format = ChallengeFormat.STANDARD_6V6;
-    public void lvlxpvp(ServerPlayer player1, ServerPlayer player2, BattleFormat battleFormat, int level, List<Integer> player1Selection, List<Integer> player2Selection) throws ChallengeBuilderException {
+
+    public void lvlxpvp(ServerPlayer player1, ServerPlayer player2, BattleFormat battleFormat, int minLevel, int maxLevel, int handicapP1, int handicapP2, List<Integer> player1Selection, List<Integer> player2Selection) throws ChallengeBuilderException {
 
         PartyStore p1Party = Cobblemon.INSTANCE.getStorage().getParty(player1);
         PartyStore p2Party = Cobblemon.INSTANCE.getStorage().getParty(player2);
 
         // Clone parties so original is not effected
-        List<BattlePokemon> player1Team = createBattleTeamFromParty(p1Party, player1Selection, level);
-        List<BattlePokemon> player2Team = createBattleTeamFromParty(p2Party, player2Selection, level);
+        List<BattlePokemon> player1Team = createBattleTeamFromParty(p1Party, player1Selection, minLevel, maxLevel, handicapP1);
+        List<BattlePokemon> player2Team = createBattleTeamFromParty(p2Party, player2Selection, minLevel, maxLevel, handicapP2);
 
         PlayerBattleActor player1Actor = new PlayerBattleActor(player1.getUUID(), player1Team);
         PlayerBattleActor player2Actor = new PlayerBattleActor(player2.getUUID(), player2Team);
@@ -44,7 +45,7 @@ public class ChallengeBattleBuilder {
     }
 
     // Method to create our own clones according to the format
-    private List<BattlePokemon> createBattleTeamFromParty(PartyStore party, List<Integer> selectedSlots, int level) throws ChallengeBuilderException {
+    private List<BattlePokemon> createBattleTeamFromParty(PartyStore party, List<Integer> selectedSlots, int minLevel, int maxLevel, int handicap) throws ChallengeBuilderException {
         List<BattlePokemon> battlePokemonList = new ArrayList<BattlePokemon>();
         if (format == ChallengeFormat.STANDARD_6V6) {
             int leadSlot = selectedSlots.get(0);
@@ -53,13 +54,17 @@ public class ChallengeBattleBuilder {
                 CobblemonChallenge.LOGGER.error("Mysterious null lead pokemon selected.");
                 throw new ChallengeBuilderException();
             }
+
             BattlePokemon leadBattlePokemon = BattlePokemon.Companion.safeCopyOf(leadPokemon);
-            battlePokemonList.add(ChallengeUtil.applyFormatTransformations(format,leadBattlePokemon, level));
+            int adjustedLevel = ChallengeUtil.getBattlePokemonAdjustedLevel(leadPokemon.getLevel(), minLevel, maxLevel, handicap);
+            battlePokemonList.add(ChallengeUtil.applyFormatTransformations(format,leadBattlePokemon, adjustedLevel));
+
             for (int slot = 0; slot < party.size(); slot++) {
                 if (slot != leadSlot) {
                     Pokemon pokemon = party.get(slot);
                     if (pokemon != null) {
-                        BattlePokemon battlePokemon = ChallengeUtil.applyFormatTransformations(format, BattlePokemon.Companion.safeCopyOf(pokemon), level);
+                        adjustedLevel = ChallengeUtil.getBattlePokemonAdjustedLevel(pokemon.getLevel(), minLevel, maxLevel, handicap);
+                        BattlePokemon battlePokemon = ChallengeUtil.applyFormatTransformations(format, BattlePokemon.Companion.safeCopyOf(pokemon), adjustedLevel);
                         battlePokemonList.add(battlePokemon);
                     }
                 }

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/command/ChallengeCommand.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/command/ChallengeCommand.java
@@ -28,87 +28,260 @@ import java.util.UUID;
 
 public class ChallengeCommand {
 
-    public record ChallengeRequest(String id, ServerPlayer challengerPlayer, ServerPlayer challengedPlayer, int level, boolean preview, long createdTime) {}
+    public record ChallengeRequest(String id, ServerPlayer challengerPlayer, ServerPlayer challengedPlayer, int minLevel, int maxLevel, int handicapP1, int handicapP2, boolean preview, long createdTime) {}
     public record LeadPokemonSelection(LeadPokemonSelectionSession selectionWrapper, long createdTime) {}
 
     private static final float MAX_DISTANCE = ChallengeConfig.MAX_CHALLENGE_DISTANCE.get();
     private static final boolean USE_DISTANCE_RESTRICTION = ChallengeConfig.CHALLENGE_DISTANCE_RESTRICTION.get();
     private static final int DEFAULT_LEVEL = ChallengeConfig.DEFAULT_CHALLENGE_LEVEL.get();
+    private static final int DEFAULT_HANDICAP = ChallengeConfig.DEFAULT_HANDICAP.get();
     private static final int CHALLENGE_COOLDOWN = ChallengeConfig.CHALLENGE_COOLDOWN_MILLIS.get();
     public static HashMap<String, ChallengeRequest> CHALLENGE_REQUESTS = new HashMap<>();
     public static final HashMap<UUID, LeadPokemonSelection> ACTIVE_SELECTIONS = new HashMap<>();
     private static final HashMap<UUID, Long> LAST_SENT_CHALLENGE = new HashMap<>();
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        // Overview:
+        //      > always player name with level or min/maxLevel are mutually exclusive
+        //      > 12 command trees
+        //      > further additions may need a UI implementation to refine/make more user friendly
 
-        // Basic challenge command that initiates a challenge with the default challenge level
-        LiteralArgumentBuilder<CommandSourceStack> baseCommandBuilder = Commands.literal("challenge")
+        // (default everything)
+        // handicap
+        // no preview
+        // handicap + no preview
+
+        // level
+        // level + handicap
+        // level + no preview
+        // level + handicap + no preview
+
+        // min/max
+        // min/max + handicap
+        // min/max + no preview
+        // min/max + handicap + no preview
+
+
+
+        // (default everything)
+        LiteralArgumentBuilder<CommandSourceStack> defaultChallengeProperties = Commands.literal("challenge")
                 .then(Commands.argument("player", EntityArgument.player())
-                        .executes(c -> challengePlayer(c, DEFAULT_LEVEL, true)));
-
-        // Basic challenge command that initiates a challenge with the default challenge level
-        LiteralArgumentBuilder<CommandSourceStack> baseCommandBuilderNoPreview = Commands.literal("challenge")
-                .then(Commands.argument("player", EntityArgument.player())
-                        .then(Commands.literal("nopreview")
-                            .executes(c -> challengePlayer(c, DEFAULT_LEVEL, false))));
-
-
-        // Challenge command that initiates a challenge with a given level
-        LiteralArgumentBuilder<CommandSourceStack> commandBuilderWithLevelOption = Commands.literal("challenge")
-                .then(Commands.argument("player", EntityArgument.player())
-                        .then(Commands.literal("level")
-                            .then(Commands.argument("setLevelTo", IntegerArgumentType.integer(1,100))
-                                 .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setLevelTo"), true)
-                             )
-                        )
-                    )
+                        .executes(c -> challengePlayer(c, DEFAULT_LEVEL, DEFAULT_LEVEL, DEFAULT_HANDICAP, DEFAULT_HANDICAP, true))
                 );
-        // Challenge command that initiates a challenge with a given level
-        LiteralArgumentBuilder<CommandSourceStack> commandBuilderWithLevelOptionNoPreview = Commands.literal("challenge")
+
+        // handicap
+        LiteralArgumentBuilder<CommandSourceStack> handicapChallengeProperties = Commands.literal("challenge")
                 .then(Commands.argument("player", EntityArgument.player())
-                        .then(Commands.literal("level")
-                                .then(Commands.argument("setLevelTo", IntegerArgumentType.integer(1,100))
-                                        .then(Commands.literal("nopreview")
-                                            .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setLevelTo"), false)
+                        .then(Commands.literal("handicapP1")
+                                .then(Commands.argument("setP1HandicapTo", IntegerArgumentType.integer(-99,99))
+                                        .then(Commands.literal("handicapP2")
+                                                .then(Commands.argument("setP2HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                        .executes(c -> challengePlayer(c,  DEFAULT_LEVEL, DEFAULT_LEVEL, IntegerArgumentType.getInteger(c, "setP1HandicapTo"), IntegerArgumentType.getInteger(c, "setP2HandicapTo"), true))
+                                                )
+
                                         )
                                 )
                         )
-                )
-            );
+                );
 
-        // Challenge command that initiates a challenge with a given level
-        LiteralArgumentBuilder<CommandSourceStack> commandBuilderWithLevelOptionNoPreviewBefore = Commands.literal("challenge")
+        // no preview
+        LiteralArgumentBuilder<CommandSourceStack> noPreviewChallengeProperties = Commands.literal("challenge")
                 .then(Commands.argument("player", EntityArgument.player())
                         .then(Commands.literal("nopreview")
-                            .then(Commands.literal("level")
-                                .then(Commands.argument("setLevelTo", IntegerArgumentType.integer(1,100))
-                                                .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setLevelTo"), false)
+                                .executes(c -> challengePlayer(c, DEFAULT_LEVEL, DEFAULT_LEVEL, DEFAULT_HANDICAP, DEFAULT_HANDICAP, false))
+                        )
+                );
+
+        // handicap + no preview
+        LiteralArgumentBuilder<CommandSourceStack> handicapNoPreviewChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("handicapP1")
+                                .then(Commands.argument("setP1HandicapTo", IntegerArgumentType.integer(-99,99))
+                                        .then(Commands.literal("handicapP2")
+                                                .then(Commands.argument("setP2HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                        .then(Commands.literal("nopreview")
+                                                                .executes(c -> challengePlayer(c,  DEFAULT_LEVEL, DEFAULT_LEVEL, IntegerArgumentType.getInteger(c, "setP1HandicapTo"), IntegerArgumentType.getInteger(c, "setP2HandicapTo"), false))
+                                                        )
                                                 )
                                         )
                                 )
                         )
                 );
 
+        // level
+        LiteralArgumentBuilder<CommandSourceStack> levelChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("level")
+                                .then(Commands.argument("setLevelTo", IntegerArgumentType.integer(1,100))
+                                        .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setLevelTo"), IntegerArgumentType.getInteger(c, "setLevelTo"), DEFAULT_HANDICAP, DEFAULT_HANDICAP, true))
+
+                                )
+                        )
+                );
+
+        // level + handicap
+        LiteralArgumentBuilder<CommandSourceStack> levelHandicapChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("level")
+                                .then(Commands.argument("setLevelTo", IntegerArgumentType.integer(1,100))
+                                        .then(Commands.literal("handicapP1")
+                                                .then(Commands.argument("setP1HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                        .then(Commands.literal("handicapP2")
+                                                                .then(Commands.argument("setP2HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                                        .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setLevelTo"), IntegerArgumentType.getInteger(c, "setLevelTo"), IntegerArgumentType.getInteger(c, "setP1HandicapTo"), IntegerArgumentType.getInteger(c, "setP2HandicapTo"), true))
+                                                                )
+                                                        )
+                                                )
+                                        )
+
+                                )
+                        )
+                );
+
+        // level + no preview
+        LiteralArgumentBuilder<CommandSourceStack> levelNoPreviewChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("level")
+                                .then(Commands.argument("setLevelTo", IntegerArgumentType.integer(1,100))
+                                        .then(Commands.literal("nopreview")
+                                                .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setLevelTo"), IntegerArgumentType.getInteger(c, "setLevelTo"), DEFAULT_HANDICAP, DEFAULT_HANDICAP, false))
+                                        )
+
+                                )
+                        )
+                );
+
+        // level + handicap + no preview
+        LiteralArgumentBuilder<CommandSourceStack> levelHandicapNoPreviewChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("level")
+                                .then(Commands.argument("setLevelTo", IntegerArgumentType.integer(1,100))
+                                        .then(Commands.literal("handicapP1")
+                                                .then(Commands.argument("setP1HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                        .then(Commands.literal("handicapP2")
+                                                                .then(Commands.argument("setP2HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                                        .then(Commands.literal("nopreview")
+                                                                                .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setLevelTo"), IntegerArgumentType.getInteger(c, "setLevelTo"), IntegerArgumentType.getInteger(c, "setP1HandicapTo"), IntegerArgumentType.getInteger(c, "setP2HandicapTo"), false))
+                                                                        )
+                                                                )
+                                                        )
+                                                )
+                                        )
+
+                                )
+                        )
+                );
+
+        // min/max
+        LiteralArgumentBuilder<CommandSourceStack> minMaxLevelChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("minLevel")
+                                .then(Commands.argument("setMinLevelTo", IntegerArgumentType.integer(1,100))
+                                        .then(Commands.literal("maxLevel")
+                                                .then(Commands.argument("setMaxLevelTo", IntegerArgumentType.integer(1,100))
+                                                        .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setMinLevelTo"), IntegerArgumentType.getInteger(c, "setMaxLevelTo"), DEFAULT_HANDICAP, DEFAULT_HANDICAP, true))
+                                                )
+                                        )
+
+                                )
+                        )
+                );
+
+        // min/max + handicap
+        LiteralArgumentBuilder<CommandSourceStack> minMaxLevelHandicapChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("minLevel")
+                                .then(Commands.argument("setMinLevelTo", IntegerArgumentType.integer(1,100))
+                                        .then(Commands.literal("maxLevel")
+                                                .then(Commands.argument("setMaxLevelTo", IntegerArgumentType.integer(1,100))
+                                                        .then(Commands.literal("handicapP1")
+                                                                .then(Commands.argument("setP1HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                                        .then(Commands.literal("handicapP2")
+                                                                                .then(Commands.argument("setP2HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                                                        .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setMinLevelTo"), IntegerArgumentType.getInteger(c, "setMaxLevelTo"), IntegerArgumentType.getInteger(c, "setP1HandicapTo"), IntegerArgumentType.getInteger(c, "setP2HandicapTo"), true))
+                                                                                )
+                                                                        )
+                                                                )
+                                                        )
+                                                )
+                                        )
+
+                                )
+                        )
+                );
+
+        // min/max + no preview
+        LiteralArgumentBuilder<CommandSourceStack> minMaxLevelNoPreviewChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("minLevel")
+                                .then(Commands.argument("setMinLevelTo", IntegerArgumentType.integer(1,100))
+                                        .then(Commands.literal("maxLevel")
+                                                .then(Commands.argument("setMaxLevelTo", IntegerArgumentType.integer(1,100))
+                                                        .then(Commands.literal("nopreview")
+                                                                .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setMinLevelTo"), IntegerArgumentType.getInteger(c, "setMaxLevelTo"), DEFAULT_HANDICAP, DEFAULT_HANDICAP, false))
+                                                        )
+                                                )
+                                        )
+
+                                )
+                        )
+                );
+
+        // min/max + handicap + no preview
+        LiteralArgumentBuilder<CommandSourceStack> minMaxLevelHandicapNoPreviewChallengeProperties = Commands.literal("challenge")
+                .then(Commands.argument("player", EntityArgument.player())
+                        .then(Commands.literal("minLevel")
+                                .then(Commands.argument("setMinLevelTo", IntegerArgumentType.integer(1,100))
+                                        .then(Commands.literal("maxLevel")
+                                                .then(Commands.argument("setMaxLevelTo", IntegerArgumentType.integer(1,100))
+                                                        .then(Commands.literal("handicapP1")
+                                                                .then(Commands.argument("setP1HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                                        .then(Commands.literal("handicapP2")
+                                                                                .then(Commands.argument("setP2HandicapTo", IntegerArgumentType.integer(-99,99))
+                                                                                        .then(Commands.literal("nopreview")
+                                                                                                .executes(c -> challengePlayer(c, IntegerArgumentType.getInteger(c, "setMinLevelTo"), IntegerArgumentType.getInteger(c, "setMaxLevelTo"), IntegerArgumentType.getInteger(c, "setP1HandicapTo"), IntegerArgumentType.getInteger(c, "setP2HandicapTo"), false))
+                                                                                        )
+                                                                                )
+                                                                        )
+                                                                )
+                                                        )
+                                                )
+                                        )
+
+                                )
+                        )
+                );
+
         // Command called to accept challenges
-        LiteralArgumentBuilder<CommandSourceStack> commandBuilderAcceptChallenge = Commands.literal("acceptchallenge")
-                        .then(Commands.argument("id", StringArgumentType.string()).executes(c -> acceptChallenge(c, StringArgumentType.getString(c, "id"))));
+        LiteralArgumentBuilder<CommandSourceStack> acceptChallengeAndProperties = Commands.literal("acceptchallenge")
+                .then(Commands.argument("id", StringArgumentType.string()).executes(c -> acceptChallenge(c, StringArgumentType.getString(c, "id"))));
         // Command called to deny challenges
-        LiteralArgumentBuilder<CommandSourceStack> commandBuilderRejectChallenge = Commands.literal("rejectchallenge")
+        LiteralArgumentBuilder<CommandSourceStack> rejectChallengeAndProperties = Commands.literal("rejectchallenge")
                 .then(Commands.argument("id", StringArgumentType.string()).executes(c -> rejectChallenge(c, StringArgumentType.getString(c, "id"))));
 
 
-        dispatcher.register(commandBuilderAcceptChallenge);
-        dispatcher.register(commandBuilderRejectChallenge);
-        dispatcher.register(commandBuilderWithLevelOption);
-        // Register nopreview section
-        dispatcher.register(commandBuilderWithLevelOptionNoPreview);
-        dispatcher.register(baseCommandBuilderNoPreview);
-        dispatcher.register(commandBuilderWithLevelOptionNoPreviewBefore);
-        dispatcher.register(baseCommandBuilder);
+        dispatcher.register(acceptChallengeAndProperties);
+        dispatcher.register(rejectChallengeAndProperties);
+
+        // 12 possible Challenge Properties Commands
+        dispatcher.register(defaultChallengeProperties);
+        dispatcher.register(handicapChallengeProperties);
+        dispatcher.register(noPreviewChallengeProperties);
+        dispatcher.register(handicapNoPreviewChallengeProperties);
+
+        dispatcher.register(levelChallengeProperties);
+        dispatcher.register(levelHandicapChallengeProperties);
+        dispatcher.register(levelNoPreviewChallengeProperties);
+        dispatcher.register(levelHandicapNoPreviewChallengeProperties);
+
+        dispatcher.register(minMaxLevelChallengeProperties);
+        dispatcher.register(minMaxLevelHandicapChallengeProperties);
+        dispatcher.register(minMaxLevelNoPreviewChallengeProperties);
+        dispatcher.register(minMaxLevelHandicapNoPreviewChallengeProperties);
 
     }
 
-    public static int challengePlayer(CommandContext<CommandSourceStack> c, int level, boolean preview) {
+    public static int challengePlayer(CommandContext<CommandSourceStack> c, int minLevel, int maxLevel, int handicapP1, int handicapP2, boolean preview) {
         try {
             ServerPlayer challengerPlayer = c.getSource().getPlayer();
             ServerPlayer challengedPlayer = c.getArgument("player", EntitySelector.class).findSinglePlayer(c.getSource());
@@ -150,14 +323,19 @@ public class ChallengeCommand {
                 return 0;
             }
 
-            ChallengeRequest request = ChallengeUtil.createChallengeRequest(challengerPlayer, challengedPlayer, level, preview);
-            CHALLENGE_REQUESTS.put(request.id, request);
-
-            String options = "";
-            if (!request.preview()) {
-                options = ChatFormatting.GOLD + " [NoTeamPreview]";
+            // make sure the min max range contains at least one functional value & defaults to maxLevel
+            if (minLevel > maxLevel){
+                minLevel = maxLevel;
             }
-            MutableComponent notificationComponent = Component.literal(ChatFormatting.YELLOW + String.format("You have been challenged to a " + ChatFormatting.BOLD + "level %d Pokemon battle" + ChatFormatting.RESET + ChatFormatting.YELLOW + " by %s!" + options, level, challengerPlayer.getDisplayName().getString()));
+
+            ChallengeRequest request = ChallengeUtil.createChallengeRequest(challengerPlayer, challengedPlayer, minLevel, maxLevel, handicapP1, handicapP2, preview);
+            CHALLENGE_REQUESTS.put(request.id, request);
+            String levelComponent = (minLevel == maxLevel) ? ChatFormatting.YELLOW + String.format("You have been challenged to a " + ChatFormatting.BOLD + "level %d Pokemon battle", maxLevel) : ChatFormatting.YELLOW + String.format("You have been challenged to a " + ChatFormatting.BOLD + "level %d - %d Pokemon battle", minLevel, maxLevel);
+            String challengerComponent = ChatFormatting.YELLOW + " by " + challengerPlayer.getDisplayName().getString() + "!";
+            String optionsComponent = request.preview() ? "" : ChatFormatting.RED + " [NoTeamPreview]";
+            String handicapComponent = (handicapP1 == 0 && handicapP2 == 0) ? "" : ChatFormatting.BLUE + " [" + challengerPlayer.getDisplayName().getString() + " handicap of " + handicapP1 + "] [" + challengedPlayer.getDisplayName().getString() + " handicap of " + handicapP2 + "]";
+            MutableComponent notificationComponent = Component.literal(levelComponent + challengerComponent + optionsComponent + handicapComponent);
+
             MutableComponent interactiveComponent = Component.literal("Click to accept or deny: ");
             interactiveComponent.append(Component.literal(ChatFormatting.GREEN + "Battle!").setStyle(Style.EMPTY.withBold(true).withClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, String.format("/acceptchallenge %s", request.id)))));
             interactiveComponent.append(Component.literal(" or "));

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/config/ChallengeConfig.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/config/ChallengeConfig.java
@@ -7,6 +7,7 @@ public class ChallengeConfig{
     public static ForgeConfigSpec.ConfigValue<Boolean> CHALLENGE_DISTANCE_RESTRICTION;
     public static ForgeConfigSpec.ConfigValue<Integer> MAX_CHALLENGE_DISTANCE;
     public static ForgeConfigSpec.ConfigValue<Integer> DEFAULT_CHALLENGE_LEVEL;
+    public static ForgeConfigSpec.ConfigValue<Integer> DEFAULT_HANDICAP;
     public static ForgeConfigSpec.ConfigValue<Integer> REQUEST_EXPIRATION_MILLIS;
     public static ForgeConfigSpec.ConfigValue<Integer> CHALLENGE_COOLDOWN_MILLIS;
 
@@ -15,6 +16,7 @@ public class ChallengeConfig{
         CHALLENGE_DISTANCE_RESTRICTION = builder.comment("Set to false if you don't want a distance restriction on challenges").define("challengeDistanceRestriction", true);
         MAX_CHALLENGE_DISTANCE = builder.comment("Max distance of a challenge if challengeDistanceRestriction is set to true").define("maxChallengeDistance", 50);
         DEFAULT_CHALLENGE_LEVEL = builder.comment("The default level to set teams to if there is no challenge specified").define("defaultChallengeLevel", 50);
+        DEFAULT_HANDICAP = builder.comment("The default handicap to set teams to if there is no handicap specified").define("defaultHandicap", 0);
         REQUEST_EXPIRATION_MILLIS = builder.comment("Time in millis before a challenge request expires").define("challengeExpirationTime", 60000);
         CHALLENGE_COOLDOWN_MILLIS = builder.comment("Time in millis before a player can send a consecutive challenge").define("challengeCooldownTime", 5000);
     }

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonMenuProvider.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonMenuProvider.java
@@ -70,15 +70,19 @@ public class LeadPokemonMenuProvider implements MenuProvider {
         PartyStore p2Party = Cobblemon.INSTANCE.getStorage().getParty(rival);
 
         setupGlassFiller(leadPokemonMenu);
+        int handicapP1 = (this.selector == request.challengerPlayer()) ? request.handicapP1() : request.handicapP2();
+        int handicapP2 = (this.selector == request.challengerPlayer()) ? request.handicapP2() : request.handicapP1();
+
         for (int x = 0; x < p1Party.size(); x ++) {
             int itemSlot = x * 9; // Lefthand column of the menu
             Pokemon pokemon = p1Party.get(x);
             if (pokemon == null) // Skip any empty slots in the pokemon team
                 continue;
             BattlePokemon copy = BattlePokemon.Companion.safeCopyOf(pokemon);
-            pokemon = ChallengeUtil.applyFormatTransformations(ChallengeFormat.STANDARD_6V6, copy, request.level()).getEffectedPokemon(); // Apply battle transformations to each pokemon
+            int adjustedLevelP1 = ChallengeUtil.getBattlePokemonAdjustedLevel(pokemon.getLevel(), request.minLevel(), request.maxLevel(), handicapP1);
+            pokemon = ChallengeUtil.applyFormatTransformations(ChallengeFormat.STANDARD_6V6, copy, adjustedLevelP1).getEffectedPokemon(); // Apply battle transformations to each pokemon
             ItemStack pokemonItem = PokemonItem.from(pokemon, 1);
-            pokemonItem.setHoverName(Component.literal(ChatFormatting.AQUA + String.format("%s (lvl%d)", pokemon.getDisplayName().getString(), request.level())));
+            pokemonItem.setHoverName(Component.literal(ChatFormatting.AQUA + String.format("%s (lvl%d)", pokemon.getDisplayName().getString(), adjustedLevelP1)));
             ListTag pokemonLoreTag = ChallengeUtil.generateLoreTagForPokemon(pokemon);
             pokemonItem.getOrCreateTagElement("display").put("Lore", pokemonLoreTag);
             leadPokemonMenu.setItem(itemSlot, leadPokemonMenu.getStateId(), pokemonItem);
@@ -93,7 +97,8 @@ public class LeadPokemonMenuProvider implements MenuProvider {
             }
             if (selectionSession.teamPreviewOn()) {
                 ItemStack pokemonItem = PokemonItem.from(pokemon, 1);
-                pokemonItem.setHoverName(Component.literal(ChatFormatting.RED + String.format("%s's %s (lvl%d)", rival.getDisplayName().getString(), pokemon.getDisplayName().getString(), request.level())));
+                int adjustedLevelP2 = ChallengeUtil.getBattlePokemonAdjustedLevel(pokemon.getLevel(), request.minLevel(), request.maxLevel(), handicapP2);
+                pokemonItem.setHoverName(Component.literal(ChatFormatting.RED + String.format("%s's %s (lvl%d)", rival.getDisplayName().getString(), pokemon.getDisplayName().getString(), adjustedLevelP2)));
                 leadPokemonMenu.setItem(itemSlot, leadPokemonMenu.getStateId(), pokemonItem);
             } else {
                 ItemStack pokemonItem = new ItemStack(CobblemonItems.POKE_BALL.asItem());

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonSelectionSession.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/gui/LeadPokemonSelectionSession.java
@@ -61,13 +61,16 @@ public class LeadPokemonSelectionSession {
     }
 
     private void beginBattle() {
-        int level = originRequest.level();
+        int minLevel = originRequest.minLevel();
+        int maxLevel = originRequest.maxLevel();
+        int handicapP1 = originRequest.handicapP1();
+        int handicapP2 = originRequest.handicapP2();
         SESSIONS_TO_CANCEL.add(this);
         challengerMenuProvider.forceCloseMenu();
         challengedMenuProvider.forceCloseMenu();
         ChallengeBattleBuilder challengeBuilder = new ChallengeBattleBuilder();
         try {
-            challengeBuilder.lvlxpvp(originRequest.challengerPlayer(), originRequest.challengedPlayer(), BattleFormat.Companion.getGEN_9_SINGLES(), level, challengerMenuProvider.selectedSlots, challengedMenuProvider.selectedSlots);
+            challengeBuilder.lvlxpvp(originRequest.challengerPlayer(), originRequest.challengedPlayer(), BattleFormat.Companion.getGEN_9_SINGLES(), minLevel, maxLevel, handicapP1, handicapP2, challengerMenuProvider.selectedSlots, challengedMenuProvider.selectedSlots);
         } catch (ChallengeBuilderException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/turtlehoarder/cobblemonchallenge/util/ChallengeUtil.java
+++ b/src/main/java/com/turtlehoarder/cobblemonchallenge/util/ChallengeUtil.java
@@ -59,9 +59,9 @@ public class ChallengeUtil {
         return player.getServer().getPlayerList().getPlayer(player.getUUID()) != null;
     }
 
-    public static ChallengeCommand.ChallengeRequest createChallengeRequest(ServerPlayer challengerPlayer, ServerPlayer challengedPlayer, int level, boolean preview) {
+    public static ChallengeCommand.ChallengeRequest createChallengeRequest(ServerPlayer challengerPlayer, ServerPlayer challengedPlayer, int minLevel, int maxLevel, int handicapP1, int handicapP2, boolean preview) {
         String key = UUID.randomUUID().toString().replaceAll("-", "");
-        ChallengeCommand.ChallengeRequest newRequest = new ChallengeCommand.ChallengeRequest(key, challengerPlayer, challengedPlayer, level, preview, System.currentTimeMillis());
+        ChallengeCommand.ChallengeRequest newRequest = new ChallengeCommand.ChallengeRequest(key, challengerPlayer, challengedPlayer, minLevel, maxLevel, handicapP1, handicapP2, preview, System.currentTimeMillis());
         return newRequest;
     }
 
@@ -126,5 +126,14 @@ public class ChallengeUtil {
             pokemon.getEffectedPokemon().heal();
         }
         return pokemon;
+    }
+
+    // Method for clamping Battle Pokemon to level range, between 1-100, & applying handicap
+    //      > the handicap applied AFTER level clamp to range
+    //      > A players level may be outside this range after the handicap is applied
+    //      >  But, the finalized handicap will be a hard clamped to (1,100)
+    public static int getBattlePokemonAdjustedLevel(int actualLevel, int minLevel, int maxLevel, int handicap) {
+        int adjustedLevel = (actualLevel < minLevel) ? minLevel + handicap : Math.min(actualLevel, maxLevel) + handicap;
+        return (adjustedLevel < 1) ? 1 : Math.min(adjustedLevel, 100);
     }
 }


### PR DESCRIPTION
Hey! Here is the changes I made to implement min/maxLevel & handicap functionality. I have tested everything on the Fabric 1.5 1.20.1 version. There were no errors there & everything functioned as expected. Some colors & property names may not be what you would prefer, so feel free to change them as you see fit. I did my best to name everything off of it's functionality. Feel free to reach out if you have any questions!


Here are the differences between Fabric & Forge in the updates I made:

    1. ChallengeConfig files
        a. Formating of properties is different
    2. ChallengeCommand files
        a. Only how the properties are formatted -> ".get()" used in Forge


Here are the individual changes made to each of the six files:

    ChallengeConfig:
        - Added DEFAULT_HANDICAP/"defaultHandicap" to config

    ChallengeCommand:
        - Refactored ChallengeRequest record with min/max level & handicap
        - Refactored ChallengeCommand.register to have 12 versions (TODO: Refactor to be more flexible & concise)
        - Refactored ChallengeCommand.challengePlayer to include min/max level & handicap
        - Added check in ChallengeCommand.challengePlayer to clamp minLevel to maxLevel
        - Refactored notification format in ChallengeCommand.challengePlayer to display level range & handicap to challengedPlayer

    ChallengeUtil:
        - Refactored ChallengeUtil.createChallengeRequest to intake min/maxLevel & handicap
        - Added method ChallengeUtil.getBattlePokemonAdjustedLevel to handle each individual pokemon level according to min/maxLevel, handicap, & clamp to (1,100)

    LeadPokemonSelectionSession:
        - Refactored LeadPokemonSelectionSession.beginBattle to use min/maxLevel & handicap to pokemon

    LeadPokemonMenuProvider:
        - Refactored LeadPokemonMenuProvider.setupPokemonRepresentation to apply min/maxLevel & handicap to pokemon

    ChallengeBattleBuilder:
        - Refactored ChallengeBattleBuilder.lvlxpvp to intake & pass min/maxLevel & handicap to ChallengeBattleBuilder.createBattleTeamFromParty
        - Refactored ChallengeBattleBuilder.createBattleTeamFromParty to apply min/maxLevel & handicap to pokemon